### PR TITLE
Add Test Stage, Dependabot for Docker image, and test Workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Build test stage
+
+on:
+  pull_request:
+    branches: [ "5.2.x" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build --target test . --file Dockerfile --tag docker-bluespice-formula:$(date +%s)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,22 @@
 FROM node:18-alpine AS builder
-
 RUN apk update && apk add --no-cache git
-RUN git clone --depth 1 https://gitlab.wikimedia.org/repos/mediawiki/services/mathoid.git /tmp/mathoid
-RUN cd /tmp/mathoid && npm install --omit=dev
-RUN cp /tmp/mathoid/config.dev.yaml /tmp/mathoid/config.yaml
-RUN find /tmp/mathoid -type d -name '.git' | xargs rm -rf {} \;
-RUN find /tmp/mathoid -type d -name 'test' | xargs rm -rf {} \;
-RUN apk del git
+RUN git clone --depth 1 https://gitlab.wikimedia.org/repos/mediawiki/services/mathoid.git /opt/mathoid
+WORKDIR /opt/mathoid
+RUN npm install --omit=dev
+RUN cp config.dev.yaml config.yaml
+
+FROM builder AS test
+RUN npm install
+RUN npm run test
+
+FROM builder AS cleanup
+RUN find /opt/mathoid -type d -name '.git' | xargs rm -rf {} \;
+RUN find /opt/mathoid -type d -name 'test' | xargs rm -rf {} \;
 
 FROM node:18-alpine
-
+WORKDIR /opt/mathoid
 RUN apk update && apk add --no-cache librsvg
-RUN mkdir -p /opt/mathoid
-
-COPY --from=builder /tmp/mathoid /opt/mathoid
+COPY --from=cleanup /opt/mathoid /opt/mathoid
 COPY ./root-fs/opt/init.sh /opt/init.sh
-
 EXPOSE 10044
-
 ENTRYPOINT [ "/opt/init.sh"]


### PR DESCRIPTION
### This PR introduces semi automated updates of the base Docker Image

Test Stage in Docker Build: Adds a dedicated test stage in the Docker image build process. (not built by default)

Dependabot: Configures Dependabot to automatically manage Docker dependency updates. (scan weekly)

GitHub Actions Workflow: Adds a new workflow that builds the Docker image test stage for pull requests. (for dependabot)